### PR TITLE
Ignore irrelevant metadata

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: maldease
 Type: Package
 Title: Command Line Analysis of MALDI-TOF Data
-Version: 2.3.0
+Version: 2.3.1
 Author: Dillon O.R. Barker
 Maintainer: Dillon O.R. Barker <dillon.barker@phac-aspc.gc.ca>
 Description: A command line tool for analysing MALDI-TOF data. Generates mass

--- a/R/maldease
+++ b/R/maldease
@@ -248,7 +248,7 @@ load_spectra <- function(spectrum_path) {
     map_lgl(isRegular)
 
   if ((!non_empty) && regular) {
-    cat("Input data are malformed\n")
+    cat(str_glue("Input data in [{spectrum_path}] are malformed\n\n"))
     quit(save = "no", status = 1)
   }
 

--- a/R/maldease
+++ b/R/maldease
@@ -145,7 +145,7 @@ process_experiment <- function(experiment_path,
                                output) {
 
   experiment_spectra <- load_spectra(experiment_path, FALSE)
-
+  print(experiment_path)
   neg_sample_name <- get_sample_name(negative_spectra)
   experiment_sample_name <- get_sample_name(experiment_spectra)
 
@@ -173,7 +173,7 @@ process_experiment <- function(experiment_path,
                                                      experiment_sample_name,
                                                      neg_sample_name,
                                                      include_only)
-
+  print("here")
   calibrator_intensity <- get_calibrator_intensity(combined_peaks,
                                                    target_definitions)
 
@@ -297,9 +297,9 @@ generate_example_definitions <- function() {
 }
 
 preprocess_spectra <- function(spectra, half_window_size) {
+
   transformed_spectra <-
     spectra %>%
-    # transformIntensity(method = "sqrt") %>%
     suppressWarnings({
       smoothIntensity(., method = "SavitzkyGolay",
                       halfWindowSize = half_window_size)
@@ -325,16 +325,20 @@ preprocess_spectra <- function(spectra, half_window_size) {
 }
 
 average_technical_replicates <- function(spectra) {
+
   samples <-
     factor(map_chr(spectra, function(x) {
       metaData(x)$sampleName
     }))
 
   avg_spectra <-
-    averageMassSpectra(spectra, labels = samples, method = "mean")
+    averageMassSpectra(spectra,
+                       labels = samples,
+                       method = "mean",
+                       mergeMetaData = FALSE)
 
   list(
-    "sample_names" = map_chr(avg_spectra, ~ metaData(.x)$sampleName),
+    "sample_names" = samples,
     "avg_spectra" = avg_spectra
   )
 }
@@ -366,6 +370,9 @@ peak_detection_spectra <- function(spectra,
       binPeaks(tolerance = 0.002) %>%
       filterPeaks(minFrequency = 0.25)
 
+    names(peaks) <- names(spectra)
+    names(noises) <- names(spectra)
+
     list("noise" = noises, "peaks" = peaks)
   }
 
@@ -378,21 +385,21 @@ combine_peaks_and_call_positives <- function(peaks,
                                              experiment_sample_name,
                                              negative_sample_name,
                                              incl_ranges) {
-
+  print(peaks)
   neg_idx <-
     peaks %>%
-    map_lgl(~ metaData(.x)$sampleName == negative_sample_name) %>%
+    imap_lgl(~ .y == negative_sample_name) %>%
     which()
 
   exp_idx <-
     peaks %>%
-    map_lgl(~ metaData(.x)$sampleName == experiment_sample_name) %>%
+    imap_lgl(~ .y == experiment_sample_name) %>%
     which()
 
   n <- peaks[[neg_idx]]
   e <- peaks[[exp_idx]]
 
-  experimental_sample_name <- metaData(e)$sampleName
+  experimental_sample_name <- names(peaks)[exp_idx]
 
   merged <-
     data.frame("mass" = e@mass, e = e@intensity) %>%

--- a/R/maldease
+++ b/R/maldease
@@ -229,14 +229,13 @@ get_sample_name <- function(spectra) {
 
 load_spectra <- function(spectrum_path) {
 
-  path_error_msg <- "Error: Not a valid MALDI spectrum [{spectrum_path}]\n\n"
-
-    spectra <-
-      tryCatch(suppressWarnings(MALDIquantForeign::import(spectrum_path)),
-               error = function(e) {
-                 cat(str_glue(path_error_msg))
-                 quit(save = "no", status = 1)
-               })
+  spectra <-
+    tryCatch(suppressWarnings(MALDIquantForeign::import(spectrum_path)),
+             error = function(e) {
+               msg <- "Error: Not a valid MALDI spectrum [{spectrum_path}]\n\n"
+               cat(str_glue(msg))
+               quit(save = "no", status = 1)
+             })
 
     non_empty <-
       spectra %>%

--- a/R/maldease
+++ b/R/maldease
@@ -92,7 +92,7 @@ main <- function() {
   analysis_time <- Sys.time()
   analysis_params <- format_analysis_parameters(args, analysis_time)
 
-  negative_spectra <- load_spectra(args[["negative_control"]], FALSE)
+  negative_spectra <- load_spectra(args[["negative_control"]])
 
   target_definitions <- load_definitions(args[["definitions"]])
 
@@ -144,7 +144,7 @@ process_experiment <- function(experiment_path,
                                analysis_params,
                                output) {
 
-  experiment_spectra <- load_spectra(experiment_path, FALSE)
+  experiment_spectra <- load_spectra(experiment_path)
 
   neg_sample_name <- get_sample_name(negative_spectra)
   experiment_sample_name <- get_sample_name(experiment_spectra)
@@ -227,17 +227,16 @@ get_sample_name <- function(spectra) {
   map_chr(spectra, ~ metaData(.x)$sampleName) %>% unique()
 }
 
-load_spectra <- function(results_path, verbose) {
+load_spectra <- function(spectrum_path) {
+
+  path_error_msg <- "Error: Not a valid MALDI spectrum [{spectrum_path}]\n\n"
 
     spectra <-
-      if (verbose) {
-        MALDIquantForeign::import(results_path)
-      } else {
-        suppressWarnings({
-          MALDIquantForeign::import(results_path)
-        })
-      }
-
+      tryCatch(suppressWarnings(MALDIquantForeign::import(spectrum_path)),
+               error = function(e) {
+                 cat(str_glue(path_error_msg))
+                 quit(save = "no", status = 1)
+               })
 
     non_empty <-
       spectra %>%

--- a/R/maldease
+++ b/R/maldease
@@ -237,23 +237,23 @@ load_spectra <- function(spectrum_path) {
                quit(save = "no", status = 1)
              })
 
-    non_empty <-
-      spectra %>%
-      map_lgl(isEmpty) %>%
-      all() %>%
-      not()
+  non_empty <-
+    spectra %>%
+    map_lgl(isEmpty) %>%
+    all() %>%
+    not()
 
-    regular <-
-      spectra %>%
-      map_lgl(isRegular)
+  regular <-
+    spectra %>%
+    map_lgl(isRegular)
 
-    if ((!non_empty) && regular) {
-      cat("Input data are malformed\n")
-      quit(save = "no", status = 1)
-    }
-
-    spectra
+  if ((!non_empty) && regular) {
+    cat("Input data are malformed\n")
+    quit(save = "no", status = 1)
   }
+
+  spectra
+}
 
 load_definitions <- function(definitions_files) {
 

--- a/R/maldease
+++ b/R/maldease
@@ -145,7 +145,7 @@ process_experiment <- function(experiment_path,
                                output) {
 
   experiment_spectra <- load_spectra(experiment_path, FALSE)
-  print(experiment_path)
+
   neg_sample_name <- get_sample_name(negative_spectra)
   experiment_sample_name <- get_sample_name(experiment_spectra)
 
@@ -173,7 +173,7 @@ process_experiment <- function(experiment_path,
                                                      experiment_sample_name,
                                                      neg_sample_name,
                                                      include_only)
-  print("here")
+
   calibrator_intensity <- get_calibrator_intensity(combined_peaks,
                                                    target_definitions)
 
@@ -385,7 +385,7 @@ combine_peaks_and_call_positives <- function(peaks,
                                              experiment_sample_name,
                                              negative_sample_name,
                                              incl_ranges) {
-  print(peaks)
+
   neg_idx <-
     peaks %>%
     imap_lgl(~ .y == negative_sample_name) %>%


### PR DESCRIPTION
Update to version 2.3.1

Ignores metadata which broke the analysis in some edge cases. This metadata was neither used nor reported, and appeared to inconsistently present. 